### PR TITLE
Add xsltproc to the Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y \
  happy \
  # development conveniences
  sudo xutils-dev \
+ # For document generation
+ xsltproc docbook-xsl \
  && apt-get clean
 
 # arc tool


### PR DESCRIPTION
Re issue #2

Untested, edited in github. Did install xsltproc and docbook-xsl in my local docker and it then builds fine
