### PR TITLE
Updated the LLVM version to 6.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y \
   # mentioned on the GHC wiki
   autoconf automake libtool make libgmp-dev ncurses-dev g++ python bzip2 ca-certificates \
   llvm \
-  llvm-3.9 llvm-4.0 \
+  llvm-6.0 \
+  
   xz-utils \
 
   ## install minimal set of haskell packages


### PR DESCRIPTION
ghc-stage2 throws a warning that only llvm-6.0.0 is supported. Thus this should fix that warning as it will use llvm-6.0.0