### PR TITLE
#12, use debian testing repo in addition to being the base system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 # from darinmorrison/haskell
 # from http://downloads.haskell.org/debian/
 RUN  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80  --recv-keys BA3CBA3FFE22B574 \
-  && echo 'deb     http://downloads.haskell.org/debian stretch main' >> /etc/apt/sources.list.d/haskell.list
+  && echo 'deb     http://downloads.haskell.org/debian testing main' >> /etc/apt/sources.list.d/haskell.list
 
 RUN apt-get update && apt-get install -y \
 


### PR DESCRIPTION
use debian testing repo in addition to being the base system. The testing system of today has the required version of happy, but "stretch" doesn't